### PR TITLE
#56 Removed 'K' suffix for chart values

### DIFF
--- a/src/sections/overview/overview-sales.js
+++ b/src/sections/overview/overview-sales.js
@@ -79,7 +79,10 @@ const useChartOptions = () => {
     },
     yaxis: {
       labels: {
-        formatter: (value) => (value > 0 ? `${value}K` : `${value}`),
+        formatter: (value) => value.toLocaleString('no-NO', {
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 0
+        }),
         offsetX: -10,
         style: {
           colors: theme.palette.text.secondary


### PR DESCRIPTION
Also formated to min 0 and max 2 decimals, and using comma seperator instead of dot (locale).